### PR TITLE
Improve antiforgery handling

### DIFF
--- a/test/testassets/TestMvcApp/Program.cs
+++ b/test/testassets/TestMvcApp/Program.cs
@@ -20,7 +20,6 @@ public class Program
         builder.Services.AddScoped<SmartPasteInference, SmartPasteInferenceForTests>();
         builder.Services.AddSmartComponents()
             .WithInferenceBackend<OpenAIInferenceBackend>();
-        builder.Services.AddAntiforgery();
 
         var app = builder.Build();
 
@@ -51,8 +50,6 @@ public class Program
         app.UseStaticFiles();
 
         app.UseRouting();
-
-        app.UseAntiforgery();
 
         app.UseAuthorization();
 


### PR DESCRIPTION
Makes smart components work in the default ASP.NET Core MVC project template without having to add antiforgery middleware.

Without this change, people would get errors like https://stackoverflow.com/questions/61829324/endpoint-contains-authorization-metadata-but-a-middleware-was-not-found-that-su. With this change, antiforgery is still enforced (and this PR adds an E2E test to show that), but it works whether or not antiforgery middleware is in the pipeline.