### PR TITLE
Allow configuring a self-hosted inference endpoint

### DIFF
--- a/RepoSharedConfig.json
+++ b/RepoSharedConfig.json
@@ -3,6 +3,7 @@
     // TODO: Add values here to run samples in this repo
     // Do not commit your changes to source control
 
+    //"SelfHosted": false,
     //"DeploymentName": "",
     //"Endpoint": "",
     //"ApiKey": ""

--- a/src/SmartComponents.Inference.OpenAI/ApiConfig.cs
+++ b/src/SmartComponents.Inference.OpenAI/ApiConfig.cs
@@ -8,17 +8,39 @@ namespace SmartComponents.Inference.OpenAI;
 
 internal class ApiConfig
 {
-    public string ApiKey { get; }
+    public string? ApiKey { get; }
     public string? DeploymentName { get; }
-    public string? Endpoint { get; }
+    public Uri? Endpoint { get; }
+    public bool SelfHosted { get; }
 
     public ApiConfig(IConfiguration config)
     {
         var configSection = config.GetRequiredSection("SmartComponents");
-        ApiKey = configSection.GetValue<string>("ApiKey")
-            ?? throw new InvalidOperationException("Missing required configuration value: SmartComponents:ApiKey");
-        DeploymentName = configSection.GetValue<string>("DeploymentName")
-            ?? throw new InvalidOperationException("Missing required configuration value: SmartComponents:DeploymentName");
-        Endpoint = configSection.GetValue<string>("Endpoint");
+
+        SelfHosted = configSection.GetValue<bool?>("SelfHosted") ?? false;
+
+        if (SelfHosted)
+        {
+            Endpoint = configSection.GetValue<Uri>("Endpoint")
+                ?? throw new InvalidOperationException("Missing required configuration value: SmartComponents:Endpoint. This is required for SelfHosted inference.");
+
+            // Ollama uses this, but other self-hosted backends might not, so it's optional.
+            DeploymentName = configSection.GetValue<string>("DeploymentName");
+
+            // Ollama doesn't use this, but other self-hosted backends might do, so it's optional.
+            ApiKey = configSection.GetValue<string>("ApiKey");
+        }
+        else
+        {
+            // If set, we assume Azure OpenAI. If not, we assume OpenAI.
+            Endpoint = configSection.GetValue<Uri>("Endpoint");
+
+            // For Azure OpenAI, it's your deployment name. For OpenAI, it's the model name.
+            DeploymentName = configSection.GetValue<string>("DeploymentName")
+                ?? throw new InvalidOperationException("Missing required configuration value: SmartComponents:DeploymentName");
+
+            ApiKey = configSection.GetValue<string>("ApiKey")
+                ?? throw new InvalidOperationException("Missing required configuration value: SmartComponents:ApiKey");
+        }
     }
 }

--- a/src/SmartComponents.Inference.OpenAI/SelfHostedLlmTransport.cs
+++ b/src/SmartComponents.Inference.OpenAI/SelfHostedLlmTransport.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace SmartComponents.Inference.OpenAI;
+
+/// <summary>
+/// Used to resolve queries using Ollama or anything else that exposes an OpenAI-compatible
+/// endpoint with a scheme/host/port set of your choice.
+/// </summary>
+internal class SelfHostedLlmTransport(Uri endpoint) : HttpClientTransport
+{
+    public override ValueTask ProcessAsync(HttpMessage message)
+    {
+        message.Request.Uri.Scheme = endpoint.Scheme;
+        message.Request.Uri.Host = endpoint.Host;
+        message.Request.Uri.Port = endpoint.Port;
+        return base.ProcessAsync(message);
+    }
+}


### PR DESCRIPTION
It was already possible to implement your own `IInferenceBackend` to use any custom backend, but this makes it simpler to use things like Ollama just by configuring the URL.