### PR TITLE
Support embedding models that take a subset of possible inputs

### DIFF
--- a/src/SmartComponents.LocalEmbeddings/LocalEmbedder.cs
+++ b/src/SmartComponents.LocalEmbeddings/LocalEmbedder.cs
@@ -34,8 +34,7 @@ public sealed partial class LocalEmbedder : IDisposable
 
     private static string GetFullPathToModelFile(string modelName, string fileName)
     {
-        var assembly = Assembly.GetEntryAssembly()!;
-        var baseDir = Path.GetDirectoryName(assembly.Location)!;
+        var baseDir = AppContext.BaseDirectory;
         var fullPath = Path.Combine(baseDir, "LocalEmbeddingsModel", modelName, fileName);
         if (!File.Exists(fullPath))
         {


### PR DESCRIPTION
This makes https://huggingface.co/Xenova/distiluse-base-multilingual-cased-v1 work, to address https://github.com/dotnet-smartcomponents/smartcomponents/issues/35

Likewise it gets the app base directory using `AppContext.BaseDirectory` which may address https://github.com/dotnet-smartcomponents/smartcomponents/issues/37