### PR TITLE
For smart paste, use JSON response to simplify parsing

### DIFF
--- a/src/SmartComponents.Inference.OpenAI/OpenAIInferenceBackend.cs
+++ b/src/SmartComponents.Inference.OpenAI/OpenAIInferenceBackend.cs
@@ -33,6 +33,7 @@ public class OpenAIInferenceBackend(IConfiguration configuration)
             MaxTokens = options.MaxTokens ?? 200,
             FrequencyPenalty = options.FrequencyPenalty ?? 0,
             PresencePenalty = options.PresencePenalty ?? 0,
+            ResponseFormat = options.RespondJson ? ChatCompletionsResponseFormat.JsonObject : ChatCompletionsResponseFormat.Text,
         };
 
         foreach (var message in options.Messages ?? Enumerable.Empty<ChatMessage>())

--- a/src/SmartComponents.Inference/ChatParameters.cs
+++ b/src/SmartComponents.Inference/ChatParameters.cs
@@ -14,6 +14,7 @@ public class ChatParameters
     public float? FrequencyPenalty { get; set; }
     public float? PresencePenalty { get; set; }
     public IList<string>? StopSequences { get; set; }
+    public bool RespondJson { get; set; }
 }
 
 public class ChatMessage(ChatMessageRole role, string text)


### PR DESCRIPTION
The only reason it wasn't done this way originally is that it predated widespread availability of JSON response sampling. But as of September 2024, the vast majority of LLM backends can respond reliably with JSON.