### PR TITLE
Resolve package vulnerability issues that prevent dotnet from running

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.18.0-alpha" />
     <PackageVersion Include="System.Numerics.Tensors" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <!-- Tests -->
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
When I tried to run the sample with `dotnet run`  with .NET 9, according to the README, dotnet run could not run due to a vulnerability issue with a dependent library.
Since there is no destructive change in system.text.json caused by upgrading the version, we have fixed the problem by upgrading the version.